### PR TITLE
fix hand wash bug

### DIFF
--- a/src/interactions/map_start/restroom.interactions.js
+++ b/src/interactions/map_start/restroom.interactions.js
@@ -4,6 +4,7 @@ export const restroomInteractions = (player, k, map) => {
     player.onCollide('restroom_toilet', () => {
         player.wasInRestroom = true;
         player.isInDialog = true;
+        player.hasHandsWashed = false;
         const dialog = ['You feel refreshed now.', 'Ready for the ride.'];
 
         if (!player.hasTalkedToBruno) {


### PR DESCRIPTION
Fixes #37

Solution: Hand wash status always reset to false on interacting with restroom_toilet.