### PR TITLE
FEAT: Adds capability to save game state and load it

### DIFF
--- a/src/factories/player.factory.js
+++ b/src/factories/player.factory.js
@@ -1,5 +1,6 @@
 import { k } from '../kplayCtx';
 import { scaleFactor, speedByScaleFactor } from '../constants';
+import { getGameState, setGameState } from '../utils/gameState';
 
 export function makePlayer(playerProps = {}, customScale = scaleFactor) {
     if (!k.getSprite('player')) {
@@ -17,6 +18,18 @@ export function makePlayer(playerProps = {}, customScale = scaleFactor) {
         });
     }
 
+    const playerState = {
+        set: function(target, key, value) {
+            const gameState = getGameState();
+            gameState.player[key] = value;
+            setGameState(gameState);
+            return true;
+        }
+    }
+    const state = new Proxy({
+        ...playerProps
+    }, playerState);
+
     const player = k.make([
         k.sprite('player', { anim: 'idle-down' }),
         k.area({
@@ -32,7 +45,7 @@ export function makePlayer(playerProps = {}, customScale = scaleFactor) {
             isInDialog: false,
             collectedCoins: 0,
             score: 0,
-            ...playerProps,
+            state: state,
         },
     ]);
 

--- a/src/factories/player.factory.js
+++ b/src/factories/player.factory.js
@@ -19,16 +19,19 @@ export function makePlayer(playerProps = {}, customScale = scaleFactor) {
     }
 
     const playerState = {
-        set: function(target, key, value) {
+        set: function (target, key, value) {
             const gameState = getGameState();
             gameState.player[key] = value;
             setGameState(gameState);
             return true;
-        }
-    }
-    const state = new Proxy({
-        ...playerProps
-    }, playerState);
+        },
+    };
+    const state = new Proxy(
+        {
+            ...playerProps,
+        },
+        playerState
+    );
 
     const player = k.make([
         k.sprite('player', { anim: 'idle-down' }),

--- a/src/interactions/map_start/bruno.interaction.js
+++ b/src/interactions/map_start/bruno.interaction.js
@@ -6,7 +6,7 @@ export const interactionWithBruno = (player, k, map) => {
         player.isInDialog = true;
         displayDialogue(conversationBruno, () => {
             player.isInDialog = false;
-            player.hasTalkedToBruno = true;
+            player.state.hasTalkedToBruno = true;
         });
     });
 };

--- a/src/interactions/map_start/enterMapCity.interaction.js
+++ b/src/interactions/map_start/enterMapCity.interaction.js
@@ -3,15 +3,15 @@ import { displayDialogue } from '../../utils';
 export const enterMapCityInteraction = (player, k, map) => {
     player.onCollide('enter_map_right', () => {
         if (
-            player.hasTalkedToBruno &&
-            player.wasInRestroom &&
-            player.hasHandsWashed
+            player.state.hasTalkedToBruno &&
+            player.state.wasInRestroom &&
+            player.state.hasHandsWashed
         ) {
             import('../../scenes/city').then((_) => {
                 k.go('city');
             });
         } else {
-            if (!player.hasTalkedToBruno) {
+            if (!player.state.hasTalkedToBruno) {
                 player.isInDialog = true;
                 displayDialogue(
                     [
@@ -25,7 +25,7 @@ export const enterMapCityInteraction = (player, k, map) => {
 
                 return;
             } else {
-                if (!player.wasInRestroom) {
+                if (!player.state.wasInRestroom) {
                     player.isInDialog = true;
                     displayDialogue(
                         [
@@ -40,7 +40,7 @@ export const enterMapCityInteraction = (player, k, map) => {
                     return;
                 }
 
-                if (!player.hasHandsWashed) {
+                if (!player.state.hasHandsWashed) {
                     player.isInDialog = true;
                     displayDialogue(
                         ['You should wash your hands first.'],

--- a/src/interactions/map_start/restroom.interactions.js
+++ b/src/interactions/map_start/restroom.interactions.js
@@ -2,12 +2,12 @@ import { displayDialogue } from '../../utils';
 
 export const restroomInteractions = (player, k, map) => {
     player.onCollide('restroom_toilet', () => {
-        player.wasInRestroom = true;
+        player.state.wasInRestroom = true;
         player.isInDialog = true;
-        player.hasHandsWashed = false;
+        player.state.hasHandsWashed = false;
         const dialog = ['You feel refreshed now.', 'Ready for the ride.'];
 
-        if (!player.hasTalkedToBruno) {
+        if (!player.state.hasTalkedToBruno) {
             dialog.push('You should talk to Bruno first.');
         }
         displayDialogue(dialog, () => {
@@ -18,7 +18,7 @@ export const restroomInteractions = (player, k, map) => {
     player.onCollide('restroom_sink', () => {
         player.isInDialog = true;
         displayDialogue(['You washed your hands. Good job!'], () => {
-            player.hasHandsWashed = true;
+            player.state.hasHandsWashed = true;
             player.isInDialog = false;
         });
     });

--- a/src/scenes/start.js
+++ b/src/scenes/start.js
@@ -4,6 +4,7 @@ import { k } from '../kplayCtx';
 import { attachInteractions } from '../interactions/map_start';
 import { addGameObjects } from '../gameObjects/map_start';
 import { addPlayerControls } from '../player.controls';
+import { getGameState } from '../utils/gameState';
 
 k.scene('start', async () => {
     const objectConfig = {
@@ -24,11 +25,8 @@ k.scene('start', async () => {
         k.vec2(0, 11)
     );
 
-    const player = makePlayer({
-        hasTalkedToBruno: false,
-        wasInRestroom: false,
-        hasHandsWashed: false,
-    });
+    const gameState = getGameState();
+    const player = makePlayer(gameState.player);
 
     player.pos = spawnpoint.player;
 

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -1,0 +1,44 @@
+const LOCAL_STORAGE_GAME_STATE_KEY = 'gameState';
+
+const initialState = () => ({
+    player: {
+        hasTalkedToBruno: false,
+        wasInRestroom: false,
+        hasHandsWashed: false,
+    }
+});
+
+// in memory state
+let currentState = undefined;
+
+export const clearSavedGame = () => {
+    localStorage.removeItemItem(LOCAL_STORAGE_GAME_STATE_KEY);
+}
+
+export const loadSavedGameState = () => {
+    const stringifiedState = localStorage.getItem(LOCAL_STORAGE_GAME_STATE_KEY) || null;
+    const savedState = JSON.parse(stringifiedState) || initialState();
+    return savedState;
+}
+
+
+export const saveGameState = (newState) => {
+    const stringifiedState = JSON.stringify(newState);
+    localStorage.setItem(LOCAL_STORAGE_GAME_STATE_KEY, stringifiedState);
+}
+
+export const getGameState = () => {
+    if (currentState) {
+        return currentState;
+    } else {
+        // persistent state
+        return loadSavedGameState();
+    }
+}
+
+export const setGameState = (newState) => {
+    currentState = newState;
+    saveGameState(currentState);
+
+    return currentState;
+}

--- a/src/utils/gameState.js
+++ b/src/utils/gameState.js
@@ -5,7 +5,7 @@ const initialState = () => ({
         hasTalkedToBruno: false,
         wasInRestroom: false,
         hasHandsWashed: false,
-    }
+    },
 });
 
 // in memory state
@@ -13,19 +13,19 @@ let currentState = undefined;
 
 export const clearSavedGame = () => {
     localStorage.removeItemItem(LOCAL_STORAGE_GAME_STATE_KEY);
-}
+};
 
 export const loadSavedGameState = () => {
-    const stringifiedState = localStorage.getItem(LOCAL_STORAGE_GAME_STATE_KEY) || null;
+    const stringifiedState =
+        localStorage.getItem(LOCAL_STORAGE_GAME_STATE_KEY) || null;
     const savedState = JSON.parse(stringifiedState) || initialState();
     return savedState;
-}
-
+};
 
 export const saveGameState = (newState) => {
     const stringifiedState = JSON.stringify(newState);
     localStorage.setItem(LOCAL_STORAGE_GAME_STATE_KEY, stringifiedState);
-}
+};
 
 export const getGameState = () => {
     if (currentState) {
@@ -34,11 +34,11 @@ export const getGameState = () => {
         // persistent state
         return loadSavedGameState();
     }
-}
+};
 
 export const setGameState = (newState) => {
     currentState = newState;
     saveGameState(currentState);
 
     return currentState;
-}
+};


### PR DESCRIPTION
Issue #33 

1. Create a in memory state and also helper functions to access the localstorage state. 
2. Create a Proxy of the player state so that every time player props are updated the proxy setter is invoked and that inturn calls the save state.
3. Maintain state props separately on player object for better visibility
4. clearSavedGame function exposed to reset the saved data. 

![save](https://github.com/user-attachments/assets/c6653abe-1ee1-449e-8b86-1dc748d99bea)

Testing instructions:
With player complete all prerequisites to go out of level one but dont go out, instead refresh the page.
App should load with saved state and then you should be able to go out without doing anything else.

Future work / improvements

- clearSavedGame can be a feature in in itself to have ui component to restart the game from the beginning.
- autosave indicator when saving is in progress.
- saving can be made async


