### PR TITLE
Clear player movement on dialog interaction

### DIFF
--- a/src/interactions/map_start/bruno.interaction.js
+++ b/src/interactions/map_start/bruno.interaction.js
@@ -1,14 +1,18 @@
 import { displayDialogueWithCharacter } from '../../utils';
 import { conversationBruno, bruno } from '../../constants';
-import { stopCharacterAnims } from '../../utils/animation';
 
 export const interactionWithBruno = (player, k, map) => {
     player.onCollide('bruno', () => {
         player.isInDialog = true;
-        stopCharacterAnims(player);
-        displayDialogueWithCharacter(bruno.name, conversationBruno, () => {
-            player.isInDialog = false;
-            player.state.hasTalkedToBruno = true;
+        displayDialogueWithCharacter({
+            k,
+            player,
+            characterName: bruno.name,
+            test: conversationBruno,
+            onDisplayEnd: () => {
+                player.isInDialog = false;
+                player.state.hasTalkedToBruno = true;
+            },
         });
     });
 };

--- a/src/interactions/map_start/bruno.interaction.js
+++ b/src/interactions/map_start/bruno.interaction.js
@@ -1,9 +1,11 @@
 import { displayDialogueWithCharacter } from '../../utils';
 import { conversationBruno, bruno } from '../../constants';
+import { stopCharacterAnims } from '../../utils/animation';
 
 export const interactionWithBruno = (player, k, map) => {
     player.onCollide('bruno', () => {
         player.isInDialog = true;
+        stopCharacterAnims(player);
         displayDialogueWithCharacter(bruno.name, conversationBruno, () => {
             player.isInDialog = false;
             player.state.hasTalkedToBruno = true;

--- a/src/interactions/map_start/enterMapCity.interaction.js
+++ b/src/interactions/map_start/enterMapCity.interaction.js
@@ -1,5 +1,4 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
-import { stopCharacterAnims } from '../../utils/animation';
 
 export const enterMapCityInteraction = (player, k, map) => {
     player.onCollide('enter_map_right', () => {
@@ -14,44 +13,47 @@ export const enterMapCityInteraction = (player, k, map) => {
         } else {
             if (!player.state.hasTalkedToBruno) {
                 player.isInDialog = true;
-                stopCharacterAnims(player);
-                displayDialogueWithoutCharacter(
-                    [
+                displayDialogueWithoutCharacter({
+                    k,
+                    player,
+                    text: [
                         'You should talk to Bruno first.',
                         'He is the guy with the beautiful suite to your left side.',
                     ],
-                    () => {
+                    onDisplayEnd: () => {
                         player.isInDialog = false;
-                    }
-                );
+                    },
+                });
 
                 return;
             } else {
                 if (!player.state.wasInRestroom) {
                     player.isInDialog = true;
-                    stopCharacterAnims(player);
-                    displayDialogueWithoutCharacter(
-                        [
+                    displayDialogueWithoutCharacter({
+                        k,
+                        player,
+                        text: [
                             'You should visit the restroom first.',
                             'Remember what bruno said? It will be a long journey.',
                             "Don't forget to wash your hands.",
                         ],
-                        () => {
+                        onDisplayEnd: () => {
                             player.isInDialog = false;
-                        }
-                    );
+                        },
+                    });
                     return;
                 }
 
                 if (!player.state.hasHandsWashed) {
                     player.isInDialog = true;
-                    stopCharacterAnims(player);
-                    displayDialogueWithoutCharacter(
-                        ['You should wash your hands first.'],
-                        () => {
+                    displayDialogueWithoutCharacter({
+                        k,
+                        player,
+                        text: ['You should wash your hands first.'],
+                        onDisplayEnd: () => {
                             player.isInDialog = false;
-                        }
-                    );
+                        },
+                    });
                 }
             }
         }

--- a/src/interactions/map_start/enterMapCity.interaction.js
+++ b/src/interactions/map_start/enterMapCity.interaction.js
@@ -1,4 +1,5 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
+import { stopCharacterAnims } from '../../utils/animation';
 
 export const enterMapCityInteraction = (player, k, map) => {
     player.onCollide('enter_map_right', () => {
@@ -13,6 +14,7 @@ export const enterMapCityInteraction = (player, k, map) => {
         } else {
             if (!player.state.hasTalkedToBruno) {
                 player.isInDialog = true;
+                stopCharacterAnims(player);
                 displayDialogueWithoutCharacter(
                     [
                         'You should talk to Bruno first.',
@@ -27,6 +29,7 @@ export const enterMapCityInteraction = (player, k, map) => {
             } else {
                 if (!player.state.wasInRestroom) {
                     player.isInDialog = true;
+                    stopCharacterAnims(player);
                     displayDialogueWithoutCharacter(
                         [
                             'You should visit the restroom first.',
@@ -42,6 +45,7 @@ export const enterMapCityInteraction = (player, k, map) => {
 
                 if (!player.state.hasHandsWashed) {
                     player.isInDialog = true;
+                    stopCharacterAnims(player);
                     displayDialogueWithoutCharacter(
                         ['You should wash your hands first.'],
                         () => {

--- a/src/interactions/map_start/mailboxMainArea.interaction.js
+++ b/src/interactions/map_start/mailboxMainArea.interaction.js
@@ -1,5 +1,4 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
-import { stopCharacterAnims } from '../../utils/animation';
 
 export const getDummyText = () => {
     const num = Math.floor(Math.random() * 11);
@@ -17,9 +16,13 @@ export const getDummyText = () => {
 export const interactionWithMainboxMainArea = (player, k, map) => {
     player.onCollide('mailbox_mainArea', () => {
         player.isInDialog = true;
-        stopCharacterAnims(player);
-        displayDialogueWithoutCharacter(getDummyText(), () => {
-            player.isInDialog = false;
+        displayDialogueWithoutCharacter({
+            k,
+            player,
+            text: getDummyText(),
+            onDisplayEnd: () => {
+                player.isInDialog = false;
+            },
         });
     });
 };

--- a/src/interactions/map_start/mailboxMainArea.interaction.js
+++ b/src/interactions/map_start/mailboxMainArea.interaction.js
@@ -1,4 +1,5 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
+import { stopCharacterAnims } from '../../utils/animation';
 
 export const getDummyText = () => {
     const num = Math.floor(Math.random() * 11);
@@ -16,6 +17,7 @@ export const getDummyText = () => {
 export const interactionWithMainboxMainArea = (player, k, map) => {
     player.onCollide('mailbox_mainArea', () => {
         player.isInDialog = true;
+        stopCharacterAnims(player);
         displayDialogueWithoutCharacter(getDummyText(), () => {
             player.isInDialog = false;
         });

--- a/src/interactions/map_start/restroom.interactions.js
+++ b/src/interactions/map_start/restroom.interactions.js
@@ -1,31 +1,35 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
-import { stopCharacterAnims } from '../../utils/animation';
 
 export const restroomInteractions = (player, k, map) => {
     player.onCollide('restroom_toilet', () => {
         player.state.wasInRestroom = true;
         player.isInDialog = true;
-        stopCharacterAnims(player);
         player.state.hasHandsWashed = false;
         const dialog = ['You feel refreshed now.', 'Ready for the ride.'];
 
         if (!player.state.hasTalkedToBruno) {
             dialog.push('You should talk to Bruno first.');
         }
-        displayDialogueWithoutCharacter(dialog, () => {
-            player.isInDialog = false;
+        displayDialogueWithoutCharacter({
+            k,
+            player,
+            dialog,
+            onDisplayEnd: () => {
+                player.isInDialog = false;
+            },
         });
     });
 
     player.onCollide('restroom_sink', () => {
         player.isInDialog = true;
-        stopCharacterAnims(player);
-        displayDialogueWithoutCharacter(
-            ['You washed your hands. Good job!'],
-            () => {
+        displayDialogueWithoutCharacter({
+            k,
+            player,
+            text: ['You washed your hands. Good job!'],
+            onDisplayEnd: () => {
                 player.state.hasHandsWashed = true;
                 player.isInDialog = false;
-            }
-        );
+            },
+        });
     });
 };

--- a/src/interactions/map_start/restroom.interactions.js
+++ b/src/interactions/map_start/restroom.interactions.js
@@ -1,9 +1,11 @@
 import { displayDialogueWithoutCharacter } from '../../utils';
+import { stopCharacterAnims } from '../../utils/animation';
 
 export const restroomInteractions = (player, k, map) => {
     player.onCollide('restroom_toilet', () => {
         player.state.wasInRestroom = true;
         player.isInDialog = true;
+        stopCharacterAnims(player);
         player.state.hasHandsWashed = false;
         const dialog = ['You feel refreshed now.', 'Ready for the ride.'];
 
@@ -17,6 +19,7 @@ export const restroomInteractions = (player, k, map) => {
 
     player.onCollide('restroom_sink', () => {
         player.isInDialog = true;
+        stopCharacterAnims(player);
         displayDialogueWithoutCharacter(
             ['You washed your hands. Good job!'],
             () => {

--- a/src/player.controls.js
+++ b/src/player.controls.js
@@ -1,8 +1,9 @@
 import { animations, stopCharacterAnims } from './utils/animation';
 
+// Manage multiple pressed buttons
+const pressed = new Set();
+
 export const addPlayerControls = (k, player) => {
-    // Manage multiple pressed buttons
-    const pressed = new Set();
     k.onButtonPress(
         ['up', 'down', 'left', 'right'],
         (dir) => player.isInDialog || pressed.add(dir)
@@ -11,6 +12,12 @@ export const addPlayerControls = (k, player) => {
         ['up', 'down', 'left', 'right'],
         (dir) => player.isInDialog || pressed.delete(dir)
     );
+    // Control what happens when a dialog starts
+    k.canvas.addEventListener('dialogueDisplayed', () => {
+        pressed.clear();
+        // TODO: should it look at the character?
+        stopCharacterAnims(player);
+    });
 
     k.onButtonPress(['up', 'down'], (dir) => {
         if (player.isInDialog) return;
@@ -40,11 +47,15 @@ export const addPlayerControls = (k, player) => {
 
     k.onButtonDown(['up', 'down', 'left', 'right'], (dir) => {
         if (player.isInDialog) return;
-        // if three buttons are pressed, the player should not move
+        // If three buttons are pressed, the player should not move
         if (pressed.size > 2) return;
+        // Also, if opposite buttons are pressed, the player should not move
+        if (pressed.has('left') && pressed.has('right')) return;
+        if (pressed.has('up') && pressed.has('down')) return;
+
+        // Move the player
         const dirX = pressed.has('left') ? -1 : pressed.has('right') ? 1 : 0;
         const dirY = pressed.has('up') ? -1 : pressed.has('down') ? 1 : 0;
-
         const moveDir = k.vec2(dirX, dirY);
         const speed =
             pressed.size === 1

--- a/src/player.controls.js
+++ b/src/player.controls.js
@@ -1,17 +1,15 @@
-import { stopCharacterAnims } from './utils/animation';
-const animations = {
-    up: 'walk-up',
-    down: 'walk-down',
-    left: 'walk-side',
-    right: 'walk-side',
-};
+import { animations, stopCharacterAnims } from './utils/animation';
 
 export const addPlayerControls = (k, player) => {
     // Manage multiple pressed buttons
     const pressed = new Set();
-    k.onButtonPress(['up', 'down', 'left', 'right'], (dir) => pressed.add(dir));
-    k.onButtonRelease(['up', 'down', 'left', 'right'], (dir) =>
-        pressed.delete(dir)
+    k.onButtonPress(
+        ['up', 'down', 'left', 'right'],
+        (dir) => player.isInDialog || pressed.add(dir)
+    );
+    k.onButtonRelease(
+        ['up', 'down', 'left', 'right'],
+        (dir) => player.isInDialog || pressed.delete(dir)
     );
 
     k.onButtonPress(['up', 'down'], (dir) => {
@@ -32,6 +30,7 @@ export const addPlayerControls = (k, player) => {
         stopCharacterAnims(player);
         pressed.delete(dir);
         if (!pressed.size) return;
+        if (player.isInDialog) return;
 
         const nextDir = [...pressed].at(-1);
         player.direction = nextDir;
@@ -40,6 +39,7 @@ export const addPlayerControls = (k, player) => {
     });
 
     k.onButtonDown(['up', 'down', 'left', 'right'], (dir) => {
+        if (player.isInDialog) return;
         // if three buttons are pressed, the player should not move
         if (pressed.size > 2) return;
         const dirX = pressed.has('left') ? -1 : pressed.has('right') ? 1 : 0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,11 +32,13 @@ const processDialogWithCharacterName = (dialogue, characterName, text) => {
     return intervalRef;
 };
 
-export async function displayDialogueWithCharacter(
+export async function displayDialogueWithCharacter({
+    k,
+    player,
     characterName,
     text,
-    onDisplayEnd = () => {}
-) {
+    onDisplayEnd = () => {},
+}) {
     const dialogueUI = document.getElementById('textbox-container');
     const dialogue = document.getElementById('dialogue');
     const closeBtn = document.getElementById('close');
@@ -81,6 +83,11 @@ export async function displayDialogueWithCharacter(
         dialogue.innerHTML = '';
         clearInterval(intervalRef);
         closeBtn.removeEventListener('click', onCloseBtnClick);
+        k.canvas.dispatchEvent(
+            new CustomEvent('dialogueClosed', {
+                detail: { k, player, characterName, text },
+            })
+        );
     }
 
     closeBtn.addEventListener('click', onCloseBtnClick);
@@ -90,12 +97,20 @@ export async function displayDialogueWithCharacter(
             closeBtn.click();
         }
     });
+
+    k.canvas.dispatchEvent(
+        new CustomEvent('dialogueDisplayed', {
+            detail: { k, player, characterName, text },
+        })
+    );
 }
 
-export async function displayDialogueWithoutCharacter(
+export async function displayDialogueWithoutCharacter({
+    k,
+    player,
     text,
-    onDisplayEnd = () => {}
-) {
+    onDisplayEnd = () => {},
+}) {
     const dialogueUI = document.getElementById('textbox-container');
     const dialogue = document.getElementById('dialogue');
     const closeBtn = document.getElementById('close');
@@ -114,6 +129,9 @@ export async function displayDialogueWithoutCharacter(
         dialogue.innerHTML = '';
         clearInterval(intervalRef);
         closeBtn.removeEventListener('click', onCloseBtnClick);
+        k.canvas.dispatchEvent(
+            new CustomEvent('dialogueClosed', { detail: { k, player, text } })
+        );
     }
 
     closeBtn.addEventListener('click', onCloseBtnClick);
@@ -123,6 +141,10 @@ export async function displayDialogueWithoutCharacter(
             closeBtn.click();
         }
     });
+
+    k.canvas.dispatchEvent(
+        new CustomEvent('dialogueDisplayed', { detail: { k, player, text } })
+    );
 }
 
 export function setCamScale(k) {

--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -1,3 +1,10 @@
+export const animations = {
+    up: 'walk-up',
+    down: 'walk-down',
+    left: 'walk-side',
+    right: 'walk-side',
+};
+
 export const stopCharacterAnims = (objectInstance) => {
     switch (objectInstance.direction) {
         case 'up':


### PR DESCRIPTION
Fixes a bug where you can keep walking even if you interacted with a dialog. 

This does not fix the focus bug discussed in https://github.com/zero-to-mastery/ZTM-Quest/issues/49