### PR TITLE
Fetch only safe-mode jokes

### DIFF
--- a/src/interactions/map_start/jokeTeller.interaction.js
+++ b/src/interactions/map_start/jokeTeller.interaction.js
@@ -8,7 +8,7 @@ export const interactionWithJokeTeller = (player, k, map) => {
 
 const fetchJoke = async (player, k) => {
     try {
-        const response = await fetch('https://v2.jokeapi.dev/joke/Any');
+        const response = await fetch('https://v2.jokeapi.dev/joke/Any?safe-mode');
         if (!response.ok) {
             throw new Error('Network response was not ok');
         }


### PR DESCRIPTION
Because some jokes are really dark, NSFW or racist, safe-mode has to be enabled. Fixes #1