### PR TITLE
Fix Dialog Overwriting Issue by Managing User Interaction with computer 

### DIFF
--- a/src/gameObjects/map_start/index.js
+++ b/src/gameObjects/map_start/index.js
@@ -6,7 +6,6 @@ import { computer } from './computer.gameObject';
 
 import { misterFu } from './misterFu.gameObject';
 
-
 import { jokeTellerNPC } from './jokeTellerNPC.gameObject';
 
 const gameObjects = [

--- a/src/gameObjects/map_start/jokeTellerNPC.gameObject.js
+++ b/src/gameObjects/map_start/jokeTellerNPC.gameObject.js
@@ -32,9 +32,7 @@ export const jokeTellerNPC = (k, map, spawnpoints) => {
         },
     });
 
-
     const spawnPoint = spawnpoints.jokeTeller || { x: 180, y: 467 };
-
 
     return k.make([
         k.sprite('jokeTeller', { anim: 'idle-side' }),

--- a/src/interactions/map_start/computer.interaction.js
+++ b/src/interactions/map_start/computer.interaction.js
@@ -21,11 +21,15 @@ export const interactionWithComputer = (player, k, map) => {
     const [computer] = k.query({ include: 'computer' });
 
     player.onCollide('computer', () => {
+        player.isInDialog = true;
         computer.play('on');
         displayDialogueWithoutCharacter({
-            k: k,
-            player: player,
+            k,
+            player,
             text: careerPathDialogue,
+            onDisplayEnd: () => {
+                player.isInDialog = false;
+            },
         });
     });
 

--- a/src/interactions/map_start/jokeTeller.interaction.js
+++ b/src/interactions/map_start/jokeTeller.interaction.js
@@ -16,7 +16,7 @@ const fetchJoke = async (player, k) => {
         if (!response.ok) {
             throw new Error('Network response was not ok');
         }
-        
+
         const jokeData = await response.json();
         handleJokeResponse(jokeData, player, k);
     } catch (error) {
@@ -30,14 +30,12 @@ const fetchJoke = async (player, k) => {
 
 const handleJokeResponse = (jokeData, player, k) => {
     let jokeText = '';
-    
-  
+
     if (jokeData.type === 'single') {
         jokeText = jokeData.joke;
     } else if (jokeData.type === 'twopart') {
         jokeText = `${jokeData.setup}\n${jokeData.delivery}`;
     }
-
 
     displayDialogueWithCharacter({
         k,
@@ -48,5 +46,4 @@ const handleJokeResponse = (jokeData, player, k) => {
             player.isInDialogue = false;
         },
     });
-
 };


### PR DESCRIPTION
@r4pt0s, The previous implementation of the computer interaction (#36 ) had a significant flaw that allowed users to move while the dialog box was loading, leading to the dialog overwriting itself repeatedly. Thanks to [this comment](https://github.com/zero-to-mastery/ZTM-Quest/issues/36#issuecomment-2391101622) from @Karine91, this issue has now been addressed.

In this pull request, I have introduced a fix that sets the `isInDialog` property to `true` when the box is open. Once the dialog box closes, this property is reset to `false`. This enhancement ensures that users cannot interact with the interface while the dialog is active, preventing any unintended behavior.

**Here is a video**

https://github.com/user-attachments/assets/022b7bbc-f039-4508-b484-e525cfa10bd4



