### PR TITLE
added sprint/running to player

### DIFF
--- a/src/player.controls.js
+++ b/src/player.controls.js
@@ -62,11 +62,15 @@ export const addPlayerControls = (player) => {
         const dirX = pressed.has('left') ? -1 : pressed.has('right') ? 1 : 0;
         const dirY = pressed.has('up') ? -1 : pressed.has('down') ? 1 : 0;
         const moveDir = k.vec2(dirX, dirY);
+
         const speed =
             pressed.size === 1
-                ? player.speed
-                : // Dot product for diagonal movement 45%
-                  player.speed * 0.707106781188095; // 1 / sqrt(2)
+                ? player.state.energy > 50
+                    ? player.speed * 1.25
+                    : player.speed * 1.1
+                : player.state.energy > 50
+                  ? player.speed * 0.707106781188095 * 1.25 // Dot product for diagonal movement 45%
+                  : player.speed * 0.707106781188095 * 1.1;
 
         player.move(moveDir.unit().scale(speed));
     });

--- a/src/player.controls.js
+++ b/src/player.controls.js
@@ -65,10 +65,10 @@ export const addPlayerControls = (player) => {
 
         const speed =
             pressed.size === 1
-                ? player.state.energy > 50
+                ? player.state.energy >= 50
                     ? player.speed * 1.25
                     : player.speed * 1.1
-                : player.state.energy > 50
+                : player.state.energy >= 50
                   ? player.speed * 0.707106781188095 * 1.25 // Dot product for diagonal movement 45%
                   : player.speed * 0.707106781188095 * 1.1;
 


### PR DESCRIPTION
This fixes #142 

The issue was to increase player speed by 25% if the player has 50% or higher energy and 10% if the player has less than 50% energy.

My solution is:
```
const speed =
            pressed.size === 1
                ? player.state.energy >= 50
                    ? player.speed * 1.25
                    : player.speed * 1.1
                : player.state.energy >= 50
                  ? player.speed * 0.707106781188095 * 1.25 // Dot product for diagonal movement 45%
                  : player.speed * 0.707106781188095 * 1.1;
```

I am checking the player's energy level, and if it is 50% or higher, I increase the speed by 25%. If the energy is less than 50%, I increase the speed by 10%."