### PR TITLE
Bug fix for bootstrap

### DIFF
--- a/src/scenes/bootstrap.js
+++ b/src/scenes/bootstrap.js
@@ -5,6 +5,7 @@ import { makePlayer } from '../factories/player.factory';
 import { k } from '../kplayCtx';
 import { getGameState } from '../utils/gameState';
 import { addPlayerControls } from './../player.controls';
+import { resetPausingVariables } from '../utils/resetPausingVariables';
 
 export async function bootstrap(bootMapCb, mapArgs) {
     const gameState = getGameState();
@@ -21,6 +22,7 @@ export async function bootstrap(bootMapCb, mapArgs) {
             (mapArgs?.enter_tag && spawnpoint[mapArgs?.enter_tag]) ||
             spawnpoint.player;
     }
+    resetPausingVariables(player);
 
     k.add(map);
     k.add(player);

--- a/src/utils/resetPausingVariables.js
+++ b/src/utils/resetPausingVariables.js
@@ -1,0 +1,3 @@
+export const resetPausingVariables = (player) => {
+    player.state = { ...player.state, isInDialog: false };
+};


### PR DESCRIPTION
Found a bug where if the player is in dialog and exits game mid-dialog, the player.state.isInDialog variable is still false - which leads to the player not being able to move. Fixed with new function to reset pausible variables in the bootstrap function.