### PR TITLE
Added quest bug fix

### DIFF
--- a/src/interactions/map_start/enterMapCityLeft.interaction.js
+++ b/src/interactions/map_start/enterMapCityLeft.interaction.js
@@ -7,22 +7,22 @@ import { map_start_quests } from '../quests/constants.quests';
 
 export const enterMapCityLeftInteraction = (player, k, map) => {
     const questName = 'Start Interacting!';
-    const hasTalkedToBruno = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'hasTalkedToBruno'
-    );
-    const wasInRestroom = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'wasInRestroom'
-    );
-    const hasWashedHands = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'hasWashedHands'
-    );
     player.onCollide('enter_map_left', () => {
+        const hasTalkedToBruno = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'hasTalkedToBruno'
+        );
+        const wasInRestroom = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'wasInRestroom'
+        );
+        const hasWashedHands = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'hasWashedHands'
+        );
         if (
             hasTalkedToBruno &&
             wasInRestroom &&

--- a/src/interactions/map_start/enterMapCityRight.interactions.js
+++ b/src/interactions/map_start/enterMapCityRight.interactions.js
@@ -7,22 +7,22 @@ import { map_start_quests } from '../quests/constants.quests';
 
 export const enterMapCityRightInteraction = (player, k, map) => {
     const questName = 'Start Interacting!';
-    const hasTalkedToBruno = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'hasTalkedToBruno'
-    );
-    const wasInRestroom = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'wasInRestroom'
-    );
-    const hasWashedHands = retrieveQuestObjectiveStatus(
-        player,
-        questName,
-        'hasWashedHands'
-    );
     player.onCollide('enter_map_right', () => {
+        const hasTalkedToBruno = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'hasTalkedToBruno'
+        );
+        const wasInRestroom = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'wasInRestroom'
+        );
+        const hasWashedHands = retrieveQuestObjectiveStatus(
+            player,
+            questName,
+            'hasWashedHands'
+        );
         // Collision point (Enter map boundary) //! NOT THE SPAWNPOINT
         if (
             hasTalkedToBruno &&


### PR DESCRIPTION
Saw a bug for when player attempts to enter map city from either side - checking all quest objective states for first quest is done before collide; This only checks the objective statuses once and will not let the player leave. 😓