### PR TITLE
feat: Add reward system for Mage challenge completion

### DIFF
--- a/src/interactions/map_campus_house_1/computer.interaction.js
+++ b/src/interactions/map_campus_house_1/computer.interaction.js
@@ -47,7 +47,9 @@ export const computerInteractions = async (player, k, map) => {
 
         if (player.state.alreadyTalkedToMage) {
             const energyUI = document.getElementById('energy-container');
-            energyUI.style.display = 'none';
+            if (energyUI) {
+                energyUI.style.display = 'none';
+            }
 
             computer.play('on');
 
@@ -56,6 +58,7 @@ export const computerInteractions = async (player, k, map) => {
 
                 if (selectedOption == 'C') {
                     updateEnergyState(player.state, -10);
+                    player.state.completedMageChallenge = true;
                     response.push("Correct!, you're a genius!");
                     response.push('It was a tough one!, You look tired');
                 } else {
@@ -75,7 +78,11 @@ export const computerInteractions = async (player, k, map) => {
                     player,
                     text: response,
                     onDisplayEnd: () => {
-                        player.state.alreadyTalkedToMage = false;
+                        // Only reset if player didn't complete the challenge successfully
+                        // Keep alreadyTalkedToMage true so they can return to Mage for reward
+                        if (!player.state.completedMageChallenge) {
+                            player.state.alreadyTalkedToMage = false;
+                        }
                     },
                 });
             });
@@ -84,7 +91,9 @@ export const computerInteractions = async (player, k, map) => {
 
     player.onCollideEnd('computer', () => {
         const energyUI = document.getElementById('energy-container');
-        energyUI.style.display = 'flex';
+        if (energyUI) {
+            energyUI.style.display = 'flex';
+        }
         computer.play('off');
     });
 };
@@ -92,7 +101,9 @@ export const computerInteractions = async (player, k, map) => {
 function showCustomPrompt(message, options, callback) {
     // Set the prompt message
     const energyUI = document.getElementById('energy-container');
-    energyUI.style.display = 'none';
+    if (energyUI) {
+        energyUI.style.display = 'none';
+    }
 
     let promotMessage = document.getElementById('prompt-message');
     promotMessage.innerHTML = message;

--- a/src/interactions/map_campus_house_1/mage.interaction.js
+++ b/src/interactions/map_campus_house_1/mage.interaction.js
@@ -1,5 +1,6 @@
 import { displayDialogue, displayPermissionBox } from '../../utils';
 import { updateEnergyState } from '../../utils/energyUpdate';
+import { addCoins } from '../../utils/coinsUpdate';
 
 const alredyUnlockText = ['The challenge is waiting for you!'];
 
@@ -34,12 +35,17 @@ const butterBeerDialog = {
     denied: ['Oh, ok. I understand...'],
 };
 
+const challengeRewardDialog = [
+    'Ah, thou hast returned! I sense the magic of success upon thee!',
+    'Thou hast conquered the challenge with great skill and wisdom!',
+    'As promised, accept this reward for thy triumph - 15 golden coins!',
+    'May they serve thee well on thy journey through the realm of ZTM!',
+];
+
 export const mageInteractions = async (player, k, map) => {
     const [computer] = map.query({ include: 'computer' });
     let mageInteractionCounter = 0;
-    player.state.alreadyTalkedToMage = false;
 
-    //TODO: You can add some prize for the player if they solve the challenge and get back to the mage
     player.onCollide('mage', async () => {
         computer.play('on');
 
@@ -85,7 +91,23 @@ export const mageInteractions = async (player, k, map) => {
         } else {
             computer.play('on');
 
-            if (player?.state?.hasButterBeer) {
+            // Check if player completed the challenge and hasn't received reward yet
+            if (
+                player?.state?.completedMageChallenge &&
+                !player?.state?.receivedMageReward
+            ) {
+                await displayDialogue({
+                    k,
+                    player,
+                    text: challengeRewardDialog,
+                    characterName: 'Mage',
+                    onDisplayEnd: () => {
+                        addCoins(15);
+                        player.state.receivedMageReward = true;
+                        player.state.completedMageChallenge = false;
+                    },
+                });
+            } else if (player?.state?.hasButterBeer) {
                 // Mage asks if he can have the butterbeer
                 let giveButterBeer = await displayPermissionBox({
                     k,


### PR DESCRIPTION
- Add 15 coins reward when player completes Mage's JavaScript challenge
- Track challenge completion with completedMageChallenge state
- Add congratulations dialog from Mage when player returns after winning
- Fix bug: Add null check for energy-container element to prevent crashes
- Prevent reward duplication with receivedMageReward flag
- Only reset alreadyTalkedToMage if player fails the challenge

Resolves TODO in mage.interaction.js about adding prize for challenge completion.