### PR TITLE
feat: Add NPCs to map_arcade near bathrooms, tables, TVs and shelves

### DIFF
--- a/src/gameObjects/map_arcade/npcsOnmap.js
+++ b/src/gameObjects/map_arcade/npcsOnmap.js
@@ -63,6 +63,26 @@ export const npcsInArcadeMap = (k, map, spawnpoints) => {
             adjustments: { xAdjust: 35, yAdjust: 25 },
             direction: 'idle-up',
         },
+        {
+            patterns: [/restroom_sinks/],
+            adjustments: { xAdjust: 50, yAdjust: 25 },
+            direction: 'idle-up',
+        },
+        {
+            patterns: [/table_right/],
+            adjustments: { xAdjust: 15, yAdjust: 20 },
+            direction: 'idle-down',
+        },
+        {
+            patterns: [/tv_near_game_machine_/],
+            adjustments: { xAdjust: 25, yAdjust: 30 },
+            direction: 'idle-up',
+        },
+        {
+            patterns: [/plush_shelf_/],
+            adjustments: { xAdjust: 50, yAdjust: 25 },
+            direction: 'idle-up',
+        },
     ];
 
     // Generate NPCs


### PR DESCRIPTION
- Add NPCs near restroom_sinks (bathroom area)
- Add NPCs near table_right (sitting at tables)
- Add NPCs near tv_near_game_machine_ (watching screens)
- Add NPCs near plush_shelf_ (looking at plush toys)

All NPCs use the existing makeNpc factory with appropriate positions and directions.