### PR TITLE
feat: Add magical flickering effect and confetti to Mage challenge

### DIFF
--- a/src/interactions/map_campus_house_1/computer.interaction.js
+++ b/src/interactions/map_campus_house_1/computer.interaction.js
@@ -29,7 +29,14 @@ const options = [
 export const computerInteractions = async (player, k, map) => {
     const [computer] = map.query({ include: 'computer' });
     player.onCollide('computer', async () => {
+        // console.log('[COMPUTER] Player state:', {
+        //     alreadyTalkedToMage: player.state.alreadyTalkedToMage,
+        //     completedMageChallenge: player.state.completedMageChallenge,
+        //     receivedMageReward: player.state.receivedMageReward,
+        // });
+
         if (!player.state.alreadyTalkedToMage) {
+            // console.log('[COMPUTER] Computer is locked');
             computer.play('on');
 
             await displayDialogue({
@@ -53,15 +60,18 @@ export const computerInteractions = async (player, k, map) => {
 
             computer.play('on');
 
+            // console.log('[COMPUTER] Showing challenge');
             showCustomPrompt(challengeText, options, async (selectedOption) => {
                 const response = [];
 
                 if (selectedOption == 'C') {
+                    // console.log('[COMPUTER] Correct answer! Setting completedMageChallenge = true');
                     updateEnergyState(player.state, -10);
                     player.state.completedMageChallenge = true;
                     response.push("Correct!, you're a genius!");
                     response.push('It was a tough one!, You look tired');
                 } else {
+                    // console.log('[COMPUTER] Wrong answer! Will reset alreadyTalkedToMage');
                     updateEnergyState(player.state, -30);
                     response.push('Incorrect! Try again next time!');
                     response.push(

--- a/src/interactions/map_campus_house_1/mage.interaction.js
+++ b/src/interactions/map_campus_house_1/mage.interaction.js
@@ -1,6 +1,7 @@
 import { displayDialogue, displayPermissionBox } from '../../utils';
 import { updateEnergyState } from '../../utils/energyUpdate';
 import { addCoins } from '../../utils/coinsUpdate';
+import { createCelebrationEffect } from '../../utils/questHandler';
 
 const alredyUnlockText = ['The challenge is waiting for you!'];
 
@@ -49,10 +50,20 @@ export const mageInteractions = async (player, k, map) => {
     player.onCollide('mage', async () => {
         computer.play('on');
 
+        // console.log('[MAGE] Player state:', {
+        //     alreadyTalkedToMage: player.state.alreadyTalkedToMage,
+        //     completedMageChallenge: player.state.completedMageChallenge,
+        //     receivedMageReward: player.state.receivedMageReward,
+        //     mageInteractionCounter: mageInteractionCounter,
+        // });
+
         if (!player.state.alreadyTalkedToMage) {
+            // console.log('[MAGE] Player has not talked to mage yet');
             mageInteractionCounter++;
+            // console.log('[MAGE] mageInteractionCounter:', mageInteractionCounter);
 
             if (mageInteractionCounter === 1) {
+                // console.log('[MAGE] First interaction - showing intro text');
                 await displayDialogue({
                     k,
                     player,
@@ -62,6 +73,7 @@ export const mageInteractions = async (player, k, map) => {
             }
 
             if (mageInteractionCounter >= 2) {
+                // console.log('[MAGE] Second+ interaction - asking permission for challenge');
                 let tryChallenge = await displayPermissionBox({
                     k,
                     player,
@@ -69,15 +81,16 @@ export const mageInteractions = async (player, k, map) => {
                 });
 
                 if (tryChallenge) {
+                    // console.log('[MAGE] Player accepted challenge - casting spell');
                     await displayDialogue({
                         k,
                         player,
                         text: spell,
                         characterName: 'Mage',
+                        addFlickerEffect: true,
                     });
 
-                    //TODO: You can add a flickering effect to the dialog box to make it more magical
-
+                    // console.log('[MAGE] Setting alreadyTalkedToMage = true');
                     player.state.alreadyTalkedToMage = true;
                 } else {
                     await displayDialogue({
@@ -89,6 +102,7 @@ export const mageInteractions = async (player, k, map) => {
                 }
             }
         } else {
+            // console.log('[MAGE] Player already talked to mage (alreadyTalkedToMage = true)');
             computer.play('on');
 
             // Check if player completed the challenge and hasn't received reward yet
@@ -96,18 +110,34 @@ export const mageInteractions = async (player, k, map) => {
                 player?.state?.completedMageChallenge &&
                 !player?.state?.receivedMageReward
             ) {
+                // console.log('[MAGE] Player completed challenge! Giving reward...');
+                // Add coins and update state BEFORE showing dialog
+                addCoins(15);
+                player.state.receivedMageReward = true;
+                player.state.completedMageChallenge = false;
+
+                createCelebrationEffect();
                 await displayDialogue({
                     k,
                     player,
                     text: challengeRewardDialog,
                     characterName: 'Mage',
-                    onDisplayEnd: () => {
-                        addCoins(15);
-                        player.state.receivedMageReward = true;
-                        player.state.completedMageChallenge = false;
-                    },
+                });
+            } else if (player?.state?.receivedMageReward) {
+                // console.log('[MAGE] Player already received reward - no more rewards');
+                // Player has already completed and received reward once
+                // They can try again but won't get more coins
+                await displayDialogue({
+                    k,
+                    player,
+                    text: [
+                        'Thou hast already proven thy worth and claimed thy reward!',
+                        'The challenge remains for thee to test thy skills, but I have no more coins to offer.',
+                    ],
+                    characterName: 'Mage',
                 });
             } else if (player?.state?.hasButterBeer) {
+                // console.log('[MAGE] Player has butterbeer');
                 // Mage asks if he can have the butterbeer
                 let giveButterBeer = await displayPermissionBox({
                     k,
@@ -136,6 +166,7 @@ export const mageInteractions = async (player, k, map) => {
                     });
                 }
             } else {
+                // console.log('[MAGE] Default message - challenge is waiting');
                 await displayDialogue({
                     k,
                     player,

--- a/src/styles/dialogs.css
+++ b/src/styles/dialogs.css
@@ -333,3 +333,48 @@
         opacity: 0;
     }
 }
+
+/* Magical Flickering Effect for Mage Dialog */
+@keyframes magical-flicker {
+    0%,
+    100% {
+        opacity: 1;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    }
+    10% {
+        opacity: 0.8;
+        box-shadow:
+            0 0 20px rgba(255, 0, 0, 0.9),
+            0 0 40px rgba(255, 0, 0, 0.7);
+    }
+    20% {
+        opacity: 1;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    }
+    35% {
+        opacity: 0.7;
+        box-shadow:
+            0 0 30px rgba(255, 0, 0, 0.9),
+            0 0 60px rgba(255, 0, 0, 0.7);
+    }
+    50% {
+        opacity: 1;
+        box-shadow:
+            0 0 40px rgba(255, 0, 0, 1),
+            0 0 80px rgba(255, 0, 0, 0.8);
+    }
+    65% {
+        opacity: 0.85;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    }
+    80% {
+        opacity: 0.9;
+        box-shadow:
+            0 0 20px rgba(255, 0, 0, 0.8),
+            0 0 40px rgba(255, 0, 0, 0.6);
+    }
+}
+
+.magical-flicker {
+    animation: magical-flicker 2s ease-in-out;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,7 @@ export async function displayDialogue({
     characterName,
     text,
     onDisplayEnd = () => {},
+    addFlickerEffect = false,
 }) {
     time.paused = true;
     player.state.isInDialog = true;
@@ -54,6 +55,11 @@ export async function displayDialogue({
     statsUI.style.display = 'none';
     dialogUI.style.display = 'block';
     miniMapUI.style.display = 'none';
+
+    // Add magical flicker effect if requested
+    if (addFlickerEffect) {
+        dialogUI.classList.add('magical-flicker');
+    }
 
     if (text.length > 1) {
         nextBtn.style.display = 'block';
@@ -87,6 +93,12 @@ export async function displayDialogue({
         dialog.innerHTML = '';
         statsUI.style.display = 'flex';
         closeBtn.removeEventListener('click', onCloseBtnClick);
+
+        // Remove magical flicker effect if it was added
+        if (addFlickerEffect) {
+            dialogUI.classList.remove('magical-flicker');
+        }
+
         k.triggerEvent('dialog-closed', { player, characterName, text });
         player.state.isInDialog = false;
         k.canvas.focus();

--- a/src/utils/questHandler.js
+++ b/src/utils/questHandler.js
@@ -2,7 +2,7 @@ import { displayDialogue } from '../utils.js';
 import { k } from '../kplayCtx.js';
 
 // Create celebration effect with confetti/stars
-const createCelebrationEffect = () => {
+export const createCelebrationEffect = () => {
     const celebrationContainer = document.createElement('div');
     celebrationContainer.className = 'celebration-container';
     document.body.appendChild(celebrationContainer);


### PR DESCRIPTION
Implemented the TODO at mage.interaction.js:79 to add a flickering effect when the Mage casts the spell. Also added confetti celebration when the player receives the reward for completing the challenge.

Changes:
- Added magical-flicker CSS animation with red glow effect in dialogs.css
- Extended displayDialogue() in utils.js to support optional addFlickerEffect parameter
- Applied flickering effect when Mage casts spell (addFlickerEffect: true)
- Exported createCelebrationEffect() from questHandler.js for reusability
- Added confetti animation when player receives Mage challenge reward
- Fixed reward state management to prevent infinite reward farming
- Added console.log statements (commented out) for future debugging